### PR TITLE
Addresses #50 - parses delimiters that all allow embedded spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 /.nyc_output
+.DS_Store

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -56,7 +56,7 @@ const parseArgs = (command) => {
       const delimeter = arg[0];
       const newNext = command.indexOf(delimeter, prevDelimiter + 1);
 
-      if (newNext < 0) throw `Bad command espcape ${delimeter} sequence near ${nextDelimiter}`
+      if (newNext < 0) throw `Bad command espcape sequence ${delimeter} near ${nextDelimiter}`
     
       arg = command.substring(prevDelimiter+1, newNext);
       prevDelimiter = newNext + 2;

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -45,39 +45,41 @@ const FS = ({
   }
 };
 
-const parseArgs = (command) => {
+const parseArgs = (cmd) => {
   const args = [];
   let nextDelimiter = 0;
   let prevDelimiter = 0;
-  while ((nextDelimiter = command.indexOf(' ', prevDelimiter)) >= 0) {
-    let arg = command.substring(prevDelimiter, nextDelimiter);
-    let quoteIndex = arg.indexOf('\'');
-    let doubleQuoteIndex = arg.indexOf('"');
+  // eslint-disable-next-line no-cond-assign
+  while ((nextDelimiter = cmd.indexOf(' ', prevDelimiter)) >= 0) {
+    let arg = cmd.substring(prevDelimiter, nextDelimiter);
+    let quoteIdx = arg.indexOf('\'');
+    let dblQuoteIdx = arg.indexOf('"');
 
-    if (quoteIndex === 0 || doubleQuoteIndex === 0) {
+    if (quoteIdx === 0 || dblQuoteIdx === 0) {
       /* The argument has a quote at the start i.e, 'id=0,streams=0 id=1,streams=1' */
       const delimiter = arg[0];
-      const endDelimiter = command.indexOf(delimiter, prevDelimiter + 1);
+      const endDelimiter = cmd.indexOf(delimiter, prevDelimiter + 1);
 
       if (endDelimiter < 0) {
         throw new Error(`Bad command escape sequence ${delimiter} near ${nextDelimiter}`);
       }
 
-      arg = command.substring(prevDelimiter + 1, endDelimiter);
+      arg = cmd.substring(prevDelimiter + 1, endDelimiter);
       prevDelimiter = endDelimiter + 2;
       args.push(arg);
-    } else if (quoteIndex > 0 || doubleQuoteIndex > 0) {
+    } else if (quoteIdx > 0 || dblQuoteIdx > 0) {
       /* The argument has a quote in it, it must be ended correctly i,e. title='test' */
-      if (quoteIndex === -1) quoteIndex = Infinity;
-      if (doubleQuoteIndex === -1) doubleQuoteIndex = Infinity;
-      const delimiter = (quoteIndex < doubleQuoteIndex) ? '\'' : '"';
-      const endDelimiter = command.indexOf(delimiter, prevDelimiter + Math.min(quoteIndex, doubleQuoteIndex) + 1);
+      if (quoteIdx === -1) quoteIdx = Infinity;
+      if (dblQuoteIdx === -1) dblQuoteIdx = Infinity;
+      const delimiter = (quoteIdx < dblQuoteIdx) ? '\'' : '"';
+      const quoteOffset = Math.min(quoteIdx, dblQuoteIdx);
+      const endDelimiter = cmd.indexOf(delimiter, prevDelimiter + quoteOffset + 1);
 
       if (endDelimiter < 0) {
         throw new Error(`Bad command escape sequence ${delimiter} near ${nextDelimiter}`);
       }
 
-      arg = command.substring(prevDelimiter, endDelimiter + 1);
+      arg = cmd.substring(prevDelimiter, endDelimiter + 1);
       prevDelimiter = endDelimiter + 2;
       args.push(arg);
     } else if (arg !== '') {
@@ -88,8 +90,8 @@ const parseArgs = (command) => {
     }
   }
 
-  if (prevDelimiter !== command.length) {
-    args.push(command.substring(prevDelimiter));
+  if (prevDelimiter !== cmd.length) {
+    args.push(cmd.substring(prevDelimiter));
   }
 
   return args;

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -45,6 +45,36 @@ const FS = ({
   }
 };
 
+const parseArgs = (command) => {
+  let args = [];
+  let nextDelimiter = 0;
+  let prevDelimiter = 0;
+  while((nextDelimiter = command.indexOf(' ', prevDelimiter)) >= 0) {
+    let arg = command.substring(prevDelimiter, nextDelimiter)
+
+    if (arg[0] === '\'' || arg[0] === '\"') {
+      const delimeter = arg[0];
+      const newNext = command.indexOf(delimeter, prevDelimiter + 1);
+
+      if (newNext < 0) throw `Bad command espcape ${delimeter} sequence near ${nextDelimiter}`
+    
+      arg = command.substring(prevDelimiter+1, newNext);
+      prevDelimiter = newNext + 2;
+    }
+    else {
+      prevDelimiter = nextDelimiter + 1;
+
+      if (arg === "") {
+        continue; 
+      }
+    }
+
+    args.push(arg)
+  }
+
+  return args;
+}
+
 const run = ({
   payload: {
     args: _args,
@@ -53,7 +83,7 @@ const run = ({
   if (Module === null) {
     throw NO_LOAD_ERROR;
   } else {
-    const args = [...defaultArgs, ..._args.trim().split(' ')].filter((s) => s.length !== 0);
+    const args = [...defaultArgs, ...parseArgs(_args))].filter((s) => s.length !== 0);
     ffmpeg(args.length, strList2ptr(Module, args));
     res.resolve({
       message: `Complete ${args.join(' ')}`,

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -53,13 +53,13 @@ const parseArgs = (command) => {
     let arg = command.substring(prevDelimiter, nextDelimiter)
 
     if (arg[0] === '\'' || arg[0] === '\"') {
-      const delimeter = arg[0];
-      const endDelimeter = command.indexOf(delimeter, prevDelimiter + 1);
+      const delimiter = arg[0];
+      const endDelimiter = command.indexOf(delimeter, prevDelimiter + 1);
 
-      if (endDelimeter < 0) throw `Bad command espcape sequence ${delimeter} near ${nextDelimiter}`
-    
-      arg = command.substring(prevDelimiter+1, endDelimeter);
-      prevDelimiter = endDelimeter + 2;
+      if (endDelimiter < 0) throw `Bad command espcape sequence ${delimeter} near ${nextDelimiter}`
+      
+      arg = command.substring(prevDelimiter+1, endDelimiter);
+      prevDelimiter = endDelimiter + 2;
     }
     else {
       prevDelimiter = nextDelimiter + 1;

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -72,6 +72,10 @@ const parseArgs = (command) => {
     args.push(arg)
   }
 
+  if (prevDelimiter != command.length) {
+    args.push(command.substring(prevDelimiter))
+  }
+
   return args;
 }
 
@@ -83,7 +87,7 @@ const run = ({
   if (Module === null) {
     throw NO_LOAD_ERROR;
   } else {
-    const args = [...defaultArgs, ...parseArgs(_args))].filter((s) => s.length !== 0);
+    const args = [...defaultArgs, ...parseArgs(_args)].filter((s) => s.length !== 0);
     ffmpeg(args.length, strList2ptr(Module, args));
     res.resolve({
       message: `Complete ${args.join(' ')}`,

--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -54,12 +54,12 @@ const parseArgs = (command) => {
 
     if (arg[0] === '\'' || arg[0] === '\"') {
       const delimeter = arg[0];
-      const newNext = command.indexOf(delimeter, prevDelimiter + 1);
+      const endDelimeter = command.indexOf(delimeter, prevDelimiter + 1);
 
-      if (newNext < 0) throw `Bad command espcape sequence ${delimeter} near ${nextDelimiter}`
+      if (endDelimeter < 0) throw `Bad command espcape sequence ${delimeter} near ${nextDelimiter}`
     
-      arg = command.substring(prevDelimiter+1, newNext);
-      prevDelimiter = newNext + 2;
+      arg = command.substring(prevDelimiter+1, endDelimeter);
+      prevDelimiter = endDelimeter + 2;
     }
     else {
       prevDelimiter = nextDelimiter + 1;

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -8,6 +8,7 @@ const OPTIONS = {
 };
 const FLAME_MP4_LENGTH = 100374;
 const META_FLAME_MP4_LENGTH = 100408;
+const META_FLAME_MP4_LENGTH_NO_SPACE = 100404;
 
 if (typeof module !== 'undefined') {
   module.exports = {
@@ -17,5 +18,6 @@ if (typeof module !== 'undefined') {
     OPTIONS,
     FLAME_MP4_LENGTH,
     META_FLAME_MP4_LENGTH,
+    META_FLAME_MP4_LENGTH_NO_SPACE,
   };
 }

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -4,8 +4,10 @@ const IS_BROWSER = typeof window !== 'undefined' && typeof window.document !== '
 const OPTIONS = {
   corePath: '../node_modules/@ffmpeg/core/ffmpeg-core.js',
   ...(IS_BROWSER ? { workerPath: '../dist/worker.dev.js' } : {}),
+  logger: ({ message }) => console.log(message),
 };
 const FLAME_MP4_LENGTH = 100374;
+const META_FLAME_MP4_LENGTH = 100408;
 
 if (typeof module !== 'undefined') {
   module.exports = {
@@ -14,5 +16,6 @@ if (typeof module !== 'undefined') {
     IS_BROWSER,
     OPTIONS,
     FLAME_MP4_LENGTH,
+    META_FLAME_MP4_LENGTH,
   };
 }

--- a/tests/ffmpeg.test.js
+++ b/tests/ffmpeg.test.js
@@ -18,3 +18,27 @@ describe('transcode()', () => {
     ));
   });
 });
+
+describe('run()', () => {
+  describe('should run a command with quoted parameters at start and a space in between', () => {
+    ['flame.avi'].forEach((name) => (
+      it(`run ${name}`, async () => {
+        await worker.write(name, `${BASE_URL}/${name}`);
+        await worker.run(`-y -i ${name} -metadata 'title="my title"' output.mp4`);
+        const { data } = await worker.read('output.mp4');
+        expect(data.length).to.be(META_FLAME_MP4_LENGTH);
+      }).timeout(TIMEOUT)
+    ));
+  });
+
+  describe('should run a command with name quoted parameters and a space in between', () => {
+    ['flame.avi'].forEach((name) => (
+      it(`run ${name}`, async () => {
+        await worker.write(name, `${BASE_URL}/${name}`);
+        await worker.run(`-y -i ${name} -metadata title="my title" output.mp4`);
+        const { data } = await worker.read('output.mp4');
+        expect(data.length).to.be(META_FLAME_MP4_LENGTH);
+      }).timeout(TIMEOUT)
+    ));
+  });
+});

--- a/tests/ffmpeg.test.js
+++ b/tests/ffmpeg.test.js
@@ -20,6 +20,17 @@ describe('transcode()', () => {
 });
 
 describe('run()', () => {
+  describe('should run a command with quoted parameters at start no spaces', () => {
+    ['flame.avi'].forEach((name) => (
+      it(`run ${name}`, async () => {
+        await worker.write(name, `${BASE_URL}/${name}`);
+        await worker.run(`-y -i ${name} -metadata 'title="test"' output.mp4`);
+        const { data } = await worker.read('output.mp4');
+        expect(data.length).to.be(META_FLAME_MP4_LENGTH_NO_SPACE);
+      }).timeout(TIMEOUT)
+    ));
+  });
+
   describe('should run a command with quoted parameters at start and a space in between', () => {
     ['flame.avi'].forEach((name) => (
       it(`run ${name}`, async () => {


### PR DESCRIPTION
This code addresses issue #50, it will now allow commands that has spaces that are enclosed in a quotes (' or ").

If it detects that the command isn't escaped, it will throw an exception.