### PR TITLE
fix: incorrect function signature in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,4 +102,4 @@ export function createFFmpeg(options?: CreateFFmpegOptions): FFmpeg;
  * Uint8Array variable for ffmpeg.wasm to consume.
  *
  */
-export function fetchFile(data: string | Buffer | Blob | File): Uint8Array;
+export function fetchFile(data: string | Buffer | Blob | File): Promise<Uint8Array>;


### PR DESCRIPTION
`fetchFile()` actually is a asyn function. It is automatically encapsulated as a Promise. 

Although the current code does not report errors, it misleads TypeScript users into missing the await keyword, which prevents them from reading the file correctly.