### PR TITLE
Allow progress callback to interpret information

### DIFF
--- a/src/utils/parseProgress.js
+++ b/src/utils/parseProgress.js
@@ -1,4 +1,5 @@
 let duration = 0;
+let ratio = 0;
 
 const ts2sec = (ts) => {
   const [h, m, s] = ts.split(':');
@@ -10,13 +11,15 @@ module.exports = (message, progress) => {
     if (message.startsWith('  Duration')) {
       const ts = message.split(', ')[0].split(': ')[1];
       const d = ts2sec(ts);
+      progress({ duration: d, ratio });
       if (duration === 0 || duration > d) {
         duration = d;
       }
     } else if (message.startsWith('frame') || message.startsWith('size')) {
       const ts = message.split('time=')[1].split(' ')[0];
       const t = ts2sec(ts);
-      progress({ ratio: t / duration });
+      ratio = t / duration;
+      progress({ ratio, time: t });
     } else if (message.startsWith('video:')) {
       progress({ ratio: 1 });
       duration = 0;


### PR DESCRIPTION
fix issues described in https://github.com/ffmpegwasm/ffmpeg.wasm/issues/152

1. Add callback execution when `Duration` changes (include `ratio` for backwards compatibility)
2. Send absolute `time` along with `ratio` when `frame` or `size` changes