### PR TITLE
Add yarn2 peerDependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,4 @@
+packageExtensions:
+  "@ffmpeg/ffmpeg@*":
+    peerDependencies:
+      "@ffmpeg/core": "*"


### PR DESCRIPTION
If you run the dependency installation on yarn2, an error occurs where the @ffmpeg / ffmpeg module cannot find @ffmpeg/core, so add the .yarnrc.yml file.

![image](https://user-images.githubusercontent.com/35059687/119456717-ebcf8080-bd75-11eb-9818-d0aedbcc5e42.png)

```
Error: @ffmpeg/ffmpeg tried to access @ffmpeg/core, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @ffmpeg/core (via "@ffmpeg/core")
```