### PR TITLE
fix error when running with vite in dev mode

### DIFF
--- a/src/browser/defaultOptions.js
+++ b/src/browser/defaultOptions.js
@@ -5,7 +5,7 @@ const { devDependencies } = require('../../package.json');
  * Default options for browser environment
  */
 module.exports = {
-  corePath: (typeof process !== 'undefined' && process.env.FFMPEG_ENV === 'development')
+  corePath: (typeof process !== 'undefined' && tyepof process?.env !== 'undefined' && process?.env?.FFMPEG_ENV === 'development')
     ? resolveURL('/node_modules/@ffmpeg/core/dist/ffmpeg-core.js')
     : `https://unpkg.com/@ffmpeg/core@${devDependencies['@ffmpeg/core'].substring(1)}/dist/ffmpeg-core.js`,
 };


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'FFMPEG_ENV' of undefined

set up a vite dev server with:
https://vitejs.dev/guide/#scaffolding-your-first-vite-project

ie: `npm init @vitejs/app web -- --template react-ts`

and import ffmpeg... ie:
`npm i --save-dev @types/node @types/react @types/react-dom @types/styled-components`
`npm i --save @ffmpeg/ffmpeg @material-ui/core @material-ui/icons styled-components`

```tsx
import React, { useState } from 'react';
import logo from './logo.svg';
import styled from 'styled-components';
import { AppBar, Toolbar, IconButton, Typography, Button } from '@material-ui/core';
import { Menu as MenuIcon } from '@material-ui/icons';
import './wasm_exec.js';
import main from './main.wasm';
import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';

const AppContainer = styled.section`
  width: 100vw;
  height: 100vh;
`;

const Main = styled.main`
  width: 100%;
  height: 100%;
  margin: 2em;
`;

const Bar = styled(AppBar)`
  flex-grow: 1;
  .MenuButton {
    margin-right: 1em;
  }
  h6 {
    flex-grow: 1;
  }
`;

declare global {
  interface Window {
    showOpenFilePicker: any;
    Go: any;
  }
}
function App() {
  const [count, setCount] = useState(0);
  const [fileContents, setFileContents] = useState(null);
  const go = new window.Go();
  const initWasm = async () => {
    let { instance, module } = await WebAssembly.instantiateStreaming(fetch(main), go.importObject);
    await go.run(instance);
  };
  initWasm();
  const handleClick = async () => {
    setCount(count + 1);
    let fileHandle;
    [fileHandle] = await window.showOpenFilePicker();
    const file = await fileHandle.getFile();
    const contents = await file.text();
    await ffmpeg.load();
    setMessage('Start transcoding');
    ffmpeg.FS('writeFile', file.name, await fetchFile(await file.arrayBuffer()));
    await ffmpeg.run('-i', file.name, 'test.avi');
    setMessage('Complete transcoding');
    const data = ffmpeg.FS('readFile', 'test.avi');
    setVideoSrc(URL.createObjectURL(new Blob([data.buffer], { type: 'video/avi' })));
    setFileContents(contents);
  };
  const [videoSrc, setVideoSrc] = useState('');
  const [message, setMessage] = useState('Click Start to transcode');
  const ffmpeg = createFFmpeg({
    log: true,
  });
  const doTranscode = async () => {
    setMessage('Loading ffmpeg-core.js');
  };
  return (
    <AppContainer className="App">
      <header className="App-header">
        <Bar position="static">
          <Toolbar>
            <IconButton className="MenuButton" edge="start" color="inherit" aria-label="menu">
              <MenuIcon />
            </IconButton>
            <Typography variant="h6">News</Typography>
            <Button color="inherit">Login</Button>
          </Toolbar>
        </Bar>
      </header>
      <Main>
        <p>Hello Vite + React!</p>
        <Button color="primary" variant="contained" onClick={handleClick}>
          count is: {count}
        </Button>
        <section>
          <video src={videoSrc} controls></video>
          <br />
        </section>
      </Main>
    </AppContainer>
  );
}

export default App;

```

now this seems to be only an issue in dev mode, if I build it's not an issue.
however, the code in your lib that I'm editing is kinda shitty, why, if the source code exists locally on a production server, would you import from npmjs? Shouldn't webpack/whatever bundler you're using handle bundling `/node_modules/@ffmpeg/core/dist/ffmpeg-core.js` ?