### PR TITLE
Added proper checking for "process" 's existence

### DIFF
--- a/src/browser/defaultOptions.js
+++ b/src/browser/defaultOptions.js
@@ -5,7 +5,7 @@ const { devDependencies } = require('../../package.json');
  * Default options for browser environment
  */
 module.exports = {
-  corePath: process.env.NODE_ENV === 'development'
+  corePath: typeof process !== 'undefined' && process.env.NODE_ENV === 'development'
     ? resolveURL('/node_modules/@ffmpeg/core/dist/ffmpeg-core.js')
     : `https://unpkg.com/@ffmpeg/core@${devDependencies['@ffmpeg/core'].substring(1)}/dist/ffmpeg-core.js`,
 };


### PR DESCRIPTION
I'm developing a [browser extension](https://github.com/avi12/youtube-downloader_old), and I'm using Rollup to bundle the files.
When Rollup attempts to import
https://github.com/ffmpegwasm/ffmpeg.wasm/blob/0f400a0961c7216aa07a7cba355dde38034d9c9b/src/index.d.ts#L102
it reaches the code in `corePath`, which attempts to use `process.env.NODE_ENV`.
Except, in a browser environment, this line will throw an error as `process` does not exist, so I added this non-null assertion.