### PR TITLE
Fix unclean `ffmpeg.exit()`

### DIFF
--- a/src/createFFmpeg.js
+++ b/src/createFFmpeg.js
@@ -178,10 +178,10 @@ module.exports = (_options = {}) => {
       throw NO_LOAD;
     } else {
       running = false;
-      Core.exit(1);
       Core = null;
       ffmpeg = null;
       runResolve = null;
+      Core.exit(1);
     }
   };
 


### PR DESCRIPTION
This fixes #242 while retaining all other behaviors.