### PR TITLE
fix: Cancel run promise if the exit() is called

### DIFF
--- a/tests/ffmpeg.test.js
+++ b/tests/ffmpeg.test.js
@@ -48,6 +48,16 @@ describe('run()', () => {
       }
     }, 500);
   }).timeout(TIMEOUT);
+
+  it('should terminate the run if exit is called', async () => {
+    const ffmpeg = createFFmpeg(OPTIONS);
+    await ffmpeg.load();
+
+    ffmpeg.run('-h').catch(e=> {
+      expect(e).to.be.equal('ffmpeg has exited')
+    });
+    expect(ffmpeg.exit()).to.throw();
+  }).timeout(TIMEOUT);
 });
 
 describe('FS()', () => {


### PR DESCRIPTION
The `.run()` promise will never be resolved if `exit` is called.

This PR will reject the `run` promise if is running:
```ts
const longRun = ffmpeg.run([/*args*/])

setTimeout(()=> {
  ffmpeg.exit()
}, timeout)

try{
  await longRun(); // before everything after this will never run
 } catch { 
  // handle error
 }
console.log('continue doing work')
```