### PR TITLE
refactor: Remove unused webpack import

### DIFF
--- a/scripts/webpack.config.dev.js
+++ b/scripts/webpack.config.dev.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const webpack = require('webpack');
 const common = require('./webpack.config.common');
 
 const genConfig = ({


### PR DESCRIPTION
Pretty self-explanatory.

This `webpack` import is unused in `scripts/webpack.config.dev.js`