### PR TITLE
build: Remove --experimental-wasm-bulk-memory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Try it: [https://ffmpegwasm.netlify.app](https://ffmpegwasm.netlify.app#demo)
 $ npm install @ffmpeg/ffmpeg @ffmpeg/core
 ```
 
-> As we are using the latest experimental features, you need to add few flags to run in Node.js
+> As we are using experimental features, you need to add flags to run in Node.js
 
 ```
 $ node --experimental-wasm-threads transcode.js

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install @ffmpeg/ffmpeg @ffmpeg/core
 > As we are using the latest experimental features, you need to add few flags to run in Node.js
 
 ```
-$ node --experimental-wasm-threads --experimental-wasm-bulk-memory transcode.js
+$ node --experimental-wasm-threads transcode.js
 ```
 
 **Browser**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "wait": "rimraf dist && wait-on http://localhost:3000/dist/ffmpeg.dev.js",
     "test": "npm-run-all -p -r start test:all",
     "test:all": "npm-run-all wait test:browser:ffmpeg test:node:all",
-    "test:node": "node --experimental-wasm-threads --experimental-wasm-bulk-memory node_modules/.bin/_mocha --exit --bail --require ./scripts/test-helper.js",
+    "test:node": "node --experimental-wasm-threads node_modules/.bin/_mocha --exit --bail --require ./scripts/test-helper.js",
     "test:node:all": "npm run test:node -- ./tests/*.test.js",
     "test:browser": "mocha-headless-chrome -a allow-file-access-from-files -a incognito -a no-sandbox -a disable-setuid-sandbox -a disable-logging -t 300000",
     "test:browser:ffmpeg": "npm run test:browser -- -f ./tests/ffmpeg.test.html"


### PR DESCRIPTION
The `--experimental-wasm-bulk-memory` is no longer supported by Chrome.

Running this repo locally against `Chrome Version 98.0.4758.80 (Official Build) (arm64)`, I'm able to run the unit tests without this flag.

With the flag in place, the tests exit early with an error message.

![2022-02-23 at 2 16 PM](https://user-images.githubusercontent.com/7367/155418365-68829c33-fd02-4a9c-b848-0f3157a18ff9.png)


With the flag removed, the tests exit happily.

![2022-02-23 at 2 17 PM](https://user-images.githubusercontent.com/7367/155418469-20893d5a-803b-4238-bc3f-3d209e274a4b.png)

