### PR TITLE
use stringToUTF8() not writeAsciiToMemory()

### DIFF
--- a/src/utils/parseArgs.js
+++ b/src/utils/parseArgs.js
@@ -1,7 +1,7 @@
 module.exports = (Core, args) => {
   const argsPtr = Core._malloc(args.length * Uint32Array.BYTES_PER_ELEMENT);
   args.forEach((s, idx) => {
-    const sz = s.length*4 + 1;
+    const sz = Core.lengthBytesUTF8(s) + 1;
     const buf = Core._malloc(sz);
     Core.stringToUTF8(s, buf, sz);
     Core.setValue(argsPtr + (Uint32Array.BYTES_PER_ELEMENT * idx), buf, 'i32');

--- a/src/utils/parseArgs.js
+++ b/src/utils/parseArgs.js
@@ -1,8 +1,9 @@
 module.exports = (Core, args) => {
   const argsPtr = Core._malloc(args.length * Uint32Array.BYTES_PER_ELEMENT);
   args.forEach((s, idx) => {
-    const buf = Core._malloc(s.length + 1);
-    Core.writeAsciiToMemory(s, buf);
+    const sz = s.length*4 + 1;
+    const buf = Core._malloc(sz);
+    Core.stringToUTF8(s, buf, sz);
     Core.setValue(argsPtr + (Uint32Array.BYTES_PER_ELEMENT * idx), buf, 'i32');
   });
   return [args.length, argsPtr];


### PR DESCRIPTION
fix issue #180 

@ffmpeg/core need to be update too!!
by using `build-with-docker.sh`, 
I can not build successful with latest commit (8f39fb6) of n4.3.1-wasm ([ffmpegwasm/ffmpeg.wasm-core](https://github.com/ffmpegwasm/ffmpeg.wasm-core/tree/8f39fb6c8a07faada0b7fc6fa7a80267754347a7))
and I build successful with b59fb55 ([ffmpegwasm/ffmpeg.wasm-core](https://github.com/ffmpegwasm/ffmpeg.wasm-core/tree/b59fb55619d22681d0e4da83023e61b663f3645a)).
so I send the PR base on b59fb55.
