### PR TITLE
use absolute path for default ffmpeg/core lib

### DIFF
--- a/src/browser/defaultOptions.js
+++ b/src/browser/defaultOptions.js
@@ -4,7 +4,7 @@ const { devDependencies } = require('../../package.json');
  * Default options for browser environment
  */
 const corePath = typeof process !== 'undefined' && process.env.NODE_ENV === 'development'
-  ? new URL('/node_modules/@ffmpeg/core/dist/ffmpeg-core.js', import.meta.url).href
+  ? new URL('@ffmpeg/core/dist/ffmpeg-core.js', import.meta.url).href
   : `https://unpkg.com/@ffmpeg/core@${devDependencies['@ffmpeg/core'].substring(1)}/dist/ffmpeg-core.js`;
 
 export default { corePath };


### PR DESCRIPTION
fixes #383 for me -- but I'm unsure about other side-effects of this