### PR TITLE
Use frames for progress ratio

### DIFF
--- a/src/createFFmpeg.js
+++ b/src/createFFmpeg.js
@@ -25,6 +25,8 @@ module.exports = (_options = {}) => {
   let logging = optLog;
   let progress = optProgress;
   let duration = 0;
+  let frames = 0;
+  let readFrames = false;
   let ratio = 0;
 
   const detectCompletion = (message) => {
@@ -53,11 +55,17 @@ module.exports = (_options = {}) => {
         prog({ duration: d, ratio });
         if (duration === 0 || duration > d) {
           duration = d;
+          readFrames = true;
         }
+      } else if (readFrames && message.startsWith('    Stream')) {
+        const fps = parseFloat(message.match(/(\d+) fps/)[1]);
+        frames = duration * fps;
+        readFrames = false;
       } else if (message.startsWith('frame') || message.startsWith('size')) {
         const ts = message.split('time=')[1].split(' ')[0];
         const t = ts2sec(ts);
-        ratio = t / duration;
+        const f = parseFloat(message.match(/frame=\s*(\d+)/)[1]);
+        ratio = Math.min(f / frames, 1);
         prog({ ratio, time: t });
       } else if (message.startsWith('video:')) {
         prog({ ratio: 1 });

--- a/src/createFFmpeg.js
+++ b/src/createFFmpeg.js
@@ -58,14 +58,23 @@ module.exports = (_options = {}) => {
           readFrames = true;
         }
       } else if (readFrames && message.startsWith('    Stream')) {
-        const fps = parseFloat(message.match(/(\d+) fps/)[1]);
-        frames = duration * fps;
+        const match = message.match(/(\d+) fps/);
+        if (match) {
+          const fps = parseFloat(match[1]);
+          frames = duration * fps;
+        } else {
+          frames = 0;
+        };
         readFrames = false;
       } else if (message.startsWith('frame') || message.startsWith('size')) {
         const ts = message.split('time=')[1].split(' ')[0];
         const t = ts2sec(ts);
         const f = parseFloat(message.match(/frame=\s*(\d+)/)[1]);
-        ratio = Math.min(f / frames, 1);
+        if (frames) {
+          ratio = Math.min(f / frames, 1);
+        } else {
+          ratio = t / duration;
+        };
         prog({ ratio, time: t });
       } else if (message.startsWith('video:')) {
         prog({ ratio: 1 });

--- a/src/createFFmpeg.js
+++ b/src/createFFmpeg.js
@@ -58,7 +58,7 @@ module.exports = (_options = {}) => {
           readFrames = true;
         }
       } else if (readFrames && message.startsWith('    Stream')) {
-        const match = message.match(/(\d+) fps/);
+        const match = message.match(/([\d\.]+) fps/);
         if (match) {
           const fps = parseFloat(match[1]);
           frames = duration * fps;


### PR DESCRIPTION
Using timestamps for progress was very inconsistent for me. When starting it would be stuck at 0% for quite a long time, then work normally up until 57%, stay stuck there a long while and then jump to 100%.

Using frames seems to work better, it starts the progress counter nearly instantly and it gets up to 100% just fine. It does stay stuck at 100% for a bit though, probably as it is finalizing.