### PR TITLE
Fix local resource error on browser (#392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ const ffmpeg = createFFmpeg({
 });
 ```
 
+Keep in mind that for compatibility with webworkers and nodejs this will default to a local path, so it will attempt to look for 'static/js/ffmpeg.core.js' locally, often resulting in a local resource error. If you wish to use a core version hosted on your own domain, you might reference it relatively like this:
+
+```javascript
+const ffmpeg = createFFmpeg({
+  corePath: new URL('static/js/ffmpeg-core.js', document.location).href,
+});
+```
+
 For the list available versions and their changelog, please check: https://github.com/ffmpegwasm/ffmpeg.wasm-core/releases
 
 ### Use single thread version

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const ffmpeg = createFFmpeg({
 });
 ```
 
-Keep in mind that for compatibility with webworkers and nodejs this will default to a local path, so it will attempt to look for 'static/js/ffmpeg.core.js' locally, often resulting in a local resource error. If you wish to use a core version hosted on your own domain, you might reference it relatively like this:
+Keep in mind that for compatibility with webworkers and nodejs this will default to a local path, so it will attempt to look for `'static/js/ffmpeg.core.js'` locally, often resulting in a local resource error. If you wish to use a core version hosted on your own domain, you might reference it relatively like this:
 
 ```javascript
 const ffmpeg = createFFmpeg({


### PR DESCRIPTION
Using `import.meta.url` leads to bugs on browser since building will hardcode those as local `file://` urls. This fix uses `document.location` instead.

In particular this fixes #392 which made impossible specifying a custom `corePath` on the same domain.

EDIT: this is now a more appropriate fix, import.meta.url is parsed instead of being hardcoded and webpack has been bumped in order to support this