### PR TITLE
Add types for mainName option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,6 +26,8 @@ export interface CreateFFmpegOptions {
     logger?: LogCallback;
     /** a function to trace the progress, a quick example is p => console.log(p) */
     progress?: ProgressCallback;
+    /** name of the main function of the ffmpeg-core.js script */
+    mainName?: string;
 }
 
 export interface FFmpeg {


### PR DESCRIPTION
The option was introduced in #235, but it's missing the types