### PR TITLE
Use path from opts

### DIFF
--- a/src/browser/getCreateFFmpegCore.js
+++ b/src/browser/getCreateFFmpegCore.js
@@ -75,11 +75,11 @@ export const getCreateFFmpegCore = async ({
     'application/javascript',
   );
   const wasmPath = await toBlobURL(
-    coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.wasm'),
+    _wasmPath !== undefined ? _wasmPath : coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.wasm'),
     'application/wasm',
   );
   const workerPath = await toBlobURL(
-    coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.worker.js'),
+    _workerPath !== undefined ? _workerPath : coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.worker.js'),
     'application/javascript',
   );
   if (typeof createFFmpegCore === 'undefined') {


### PR DESCRIPTION
It could enable user cache the wasm file to local storage, and make custom loading progress bar possible.