### PR TITLE
fix(#466): image duration is skipped

### DIFF
--- a/src/createFFmpeg.js
+++ b/src/createFFmpeg.js
@@ -53,7 +53,7 @@ module.exports = (_options = {}) => {
         const ts = message.split(', ')[0].split(': ')[1];
         const d = ts2sec(ts);
         prog({ duration: d, ratio });
-        if (duration === 0 || duration > d) {
+        if ((duration === 0 || duration > d) && d >= 1) {
           duration = d;
           readFrames = true;
         }


### PR DESCRIPTION
Fixes: https://github.com/ffmpegwasm/ffmpeg.wasm/issues/466