### PR TITLE
fix uncaught error in browser's getCreateFFmpegCore()

### DIFF
--- a/src/browser/getCreateFFmpegCore.js
+++ b/src/browser/getCreateFFmpegCore.js
@@ -83,12 +83,13 @@ export const getCreateFFmpegCore = async ({
     'application/javascript',
   );
   if (typeof createFFmpegCore === 'undefined') {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const script = document.createElement('script');
       const eventHandler = () => {
         script.removeEventListener('load', eventHandler);
         if (typeof createFFmpegCore === 'undefined') {
-          throw Error(CREATE_FFMPEG_CORE_IS_NOT_DEFINED(coreRemotePath));
+          reject(Error(CREATE_FFMPEG_CORE_IS_NOT_DEFINED(coreRemotePath)));
+          return;
         }
         log('info', 'ffmpeg-core.js script loaded');
         resolve({


### PR DESCRIPTION
An error is thrown when loading `corePath` fails, but the error thrown in the callback function can not be caught in the Promise context, so I changed the keyword from `thrown` to `reject`.