### PR TITLE
Fix webpack automatic publicPath error on tests

### DIFF
--- a/packages/ffmpeg/webpack.config.js
+++ b/packages/ffmpeg/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
     extensions: [".js"],
   },
   output: {
+    // disable automatic publicPath
+    publicPath: "",
     path: path.resolve(__dirname, "dist/umd"),
     filename: "ffmpeg.js",
     library: "FFmpegWASM",


### PR DESCRIPTION
PR for https://github.com/ffmpegwasm/ffmpeg.wasm/issues/545
I've test it locally (building and replacing the dist folder in node_modules of my project)