### PR TITLE
Fixed not being able to unsubscribe events

### DIFF
--- a/packages/ffmpeg/src/classes.ts
+++ b/packages/ffmpeg/src/classes.ts
@@ -148,9 +148,9 @@ export class FFmpeg {
     callback: LogEventCallback | ProgressEventCallback
   ) {
     if (event === "log") {
-      this.#logEventCallbacks.filter((f) => f !== callback);
+      this.#logEventCallbacks = this.#logEventCallbacks.filter((f) => f !== callback);
     } else if (event === "progress") {
-      this.#progressEventCallbacks.filter((f) => f !== callback);
+      this.#progressEventCallbacks = this.#progressEventCallbacks.filter((f) => f !== callback);
     }
   }
 


### PR DESCRIPTION
`Array.prototype.filter` creates a new array but it was never assigned thus events were never unsubscribed.