### PR TITLE
ffmpeg: allow import in nodejs

### DIFF
--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -7,8 +7,11 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/umd/ffmpeg.js"
+      "node": "./dist/esm/empty.js",
+      "default": {
+        "import": "./dist/esm/index.js",
+        "require": "./dist/umd/ffmpeg.js"
+      }
     }
   },
   "scripts": {

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "node": "./dist/esm/empty.js",
+      "node": "./dist/esm/empty.mjs",
       "default": {
         "import": "./dist/esm/index.js",
         "require": "./dist/umd/ffmpeg.js"

--- a/packages/ffmpeg/src/empty.mts
+++ b/packages/ffmpeg/src/empty.mts
@@ -1,0 +1,7 @@
+// File to be imported in node enviroments
+
+export class FFmpeg {
+  constructor() {
+    throw new Error("ffmpeg.wasm does not support nodejs");
+  }
+}

--- a/packages/ffmpeg/src/empty.ts
+++ b/packages/ffmpeg/src/empty.ts
@@ -1,3 +1,0 @@
-/**
- * Empty file to be imported in node enviroments
- */

--- a/packages/ffmpeg/src/empty.ts
+++ b/packages/ffmpeg/src/empty.ts
@@ -1,0 +1,3 @@
+/**
+ * Empty file to be imported in node enviroments
+ */


### PR DESCRIPTION
Importing `@ffmpeg/ffmpeg` in nodejs results in `SyntaxError: Unexpected token 'export'`. This can lead to problems in a SSR application.

This just exports an empty file and any use of a function/class will result in an error.