### PR TITLE
Providing webpackIgnore is crucial for a successful Webpack build.

### DIFF
--- a/packages/ffmpeg/src/worker.ts
+++ b/packages/ffmpeg/src/worker.ts
@@ -58,7 +58,7 @@ const load = async ({
     // when web worker type is `module`.
     (self as WorkerGlobalScope).createFFmpegCore = (
       (await import(
-        /* @vite-ignore */ _coreURL
+        /* webpackIgnore: true *//* @vite-ignore */ _coreURL
       )) as ImportedFFmpegCoreModuleFactory
     ).default;
 


### PR DESCRIPTION
Without this change, I've got an error here:

> Compiled with problems:
> ×
> WARNING in ./node_modules/@ffmpeg/ffmpeg/dist/esm/worker.js 20:39-21:35
> Critical dependency: the request of a dependency is an expression