### PR TITLE
Added type=module to @ffmpeg/util package.json

### DIFF
--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -3,6 +3,7 @@
   "version": "0.12.1",
   "description": "browser utils for @ffmpeg/*",
   "main": "./dist/cjs/index.js",
+  "type": "module",
   "types": "./dist/cjs/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
I'm using Vite and pnpm and when trying to use @ffmpeg/util I'm getting this error:

```
import { ERROR_RESPONSE_BODY_READER, ERROR_INCOMPLETED_DOWNLOAD, } from "./errors.js";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
```

Adding `"type": "module"` to `@ffmpeg/util`'s `package.json` fixes the error 👍 