### PR TITLE
add export entry for wasm and worker files

### DIFF
--- a/packages/core-mt/package.json
+++ b/packages/core-mt/package.json
@@ -7,6 +7,10 @@
     ".": {
       "import": "./dist/esm/ffmpeg-core.js",
       "require": "./dist/umd/ffmpeg-core.js"
+    },
+    "./wasm": {
+      "import": "./dist/esm/ffmpeg-core.wasm",
+      "require": "./dist/umd/ffmpeg-core.wasm"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
     ".": {
       "import": "./dist/esm/ffmpeg-core.js",
       "require": "./dist/umd/ffmpeg-core.js"
+    },
+    "./wasm": {
+      "import": "./dist/esm/ffmpeg-core.wasm",
+      "require": "./dist/umd/ffmpeg-core.wasm"
     }
   },
   "files": [


### PR DESCRIPTION
To enable usage like

```
import ffmpegWasm from '@ffmpeg/core/wasm';
```

this will be convenient when using file-loader in webpack.
