### PR TITLE
Fix worker coreURL for ESM

### DIFF
--- a/packages/ffmpeg/src/worker.ts
+++ b/packages/ffmpeg/src/worker.ts
@@ -54,7 +54,7 @@ const load = async ({
     // when web worker type is `classic`.
     importScripts(_coreURL);
   } catch {
-    if (!_coreURL) _coreURL = CORE_URL.replace('/umd/', '/esm/');
+    if (!_coreURL || _coreURL === CORE_URL) _coreURL = CORE_URL.replace('/umd/', '/esm/');
     // when web worker type is `module`.
     (self as WorkerGlobalScope).createFFmpegCore = (
       (await import(


### PR DESCRIPTION
Currently when loading the core module from the ESM worker if `coreURL` is not specified in the config, the default unpkg UMD path is used instead of the ESM path.  Basically `_coreURL` is always set inside the `try` so it is never falsey in the `catch`, therefore the `esm` replacement never occurs.

I believe this is what #602 was attempting to fix as well, this is a bit simpler fix.  