### PR TITLE
core-mt: add worker export

### DIFF
--- a/packages/core-mt/package.json
+++ b/packages/core-mt/package.json
@@ -11,6 +11,10 @@
     "./wasm": {
       "import": "./dist/esm/ffmpeg-core.wasm",
       "require": "./dist/umd/ffmpeg-core.wasm"
+    },
+    "./worker": {
+      "import": "./dist/esm/ffmpeg-core.worker.js",
+      "require": "./dist/umd/ffmpeg-core.worker.js"
     }
   },
   "files": [


### PR DESCRIPTION
Enables usage like: `import FFmpegWorker from '@ffmpeg/core/worker'`.

Follow up to PR https://github.com/ffmpegwasm/ffmpeg.wasm/pull/642, which did not actually add an export for worker files.