### PR TITLE
Export `@ffmpeg/ffmpeg` TS types declared in `src/types.ts`

### DIFF
--- a/packages/ffmpeg/src/index.ts
+++ b/packages/ffmpeg/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./classes.js";
+export * from "./types.js";


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The `@ffmpeg/ffmpeg` package.json declaration file claims that library types are exported at `index.d.ts`:
```
  "types": "./dist/esm/index.d.ts",
  "exports": {
    ".": {
      "types": "./dist/esm/index.d.ts",
```

However, in reality, the only type that is exported is the `FFmpeg` class declaration from `classes.d.ts`.

The `FFmpeg` class utilizes TypeScript types such as `LogEventCallback`, `ProgressEventCallback`, `FFMessageLoadConfig`, and `FFMessageOptions`, which are declared in `types.ts`.

I would like to utilize these types to create a custom wrapper around the `FFmpeg` class. However, currently, it seems impossible to export them.

**Describe the solution you'd like**
I propose exporting all types declared in types.ts at the index.ts root file as follows:

```diff
export * from "./classes.js";
+ export * from "./types.js";
```

**Describe alternatives you've considered**
I attempted to use the `@ffmpeg/types` library, but it mostly contains unrelated or unuseful content that doesn't meet my needs.
Additionally, I tried to directly import from the `types.d.ts` file in the dist, but my resolver couldn't locate such a file:
```
import type { LogEventCallback } from "@ffmpeg/ffmpeg/dist/esm/types.d.ts";
``` 
