### PR TITLE
Fix SvelteKit example link

### DIFF
--- a/apps/website/docs/getting-started/examples.md
+++ b/apps/website/docs/getting-started/examples.md
@@ -58,7 +58,7 @@ any of the examples.
         img="/img/sveltekit-vite.png"
         title="SvelteKit + Vite"
         desc="SvelteKit with Vite (multithread version)"
-        url="https://github.com/ffmpegwasm/ffmpeg.wasm/tree/main/apps/sveltekit-vite-app"
+        url="https://github.com/ffmpegwasm/ffmpeg.wasm/tree/main/apps/sveltekit-app"
       />
     </Grid>
   </Grid>


### PR DESCRIPTION
I noticed that the link to the SvelteKit example in Github was broken due to there being no "vite" in the url.

This PR fixes the example card so that the link no longer leads to a 404