### PR TITLE
Added worker export to core and core-mt package.json

### DIFF
--- a/packages/core-mt/package.json
+++ b/packages/core-mt/package.json
@@ -11,6 +11,10 @@
     "./wasm": {
       "import": "./dist/esm/ffmpeg-core.wasm",
       "require": "./dist/umd/ffmpeg-core.wasm"
+    },
+    "./worker": {
+      "import": "./dist/esm/ffmpeg-core.worker.js",
+      "require": "./dist/umd/ffmpeg-core.worker.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,10 @@
     "./wasm": {
       "import": "./dist/esm/ffmpeg-core.wasm",
       "require": "./dist/umd/ffmpeg-core.wasm"
+    },
+    "./worker": {
+      "import": "./dist/esm/ffmpeg-core.worker.js",
+      "require": "./dist/umd/ffmpeg-core.worker.js"
     }
   },
   "files": [


### PR DESCRIPTION
This allows the ESM based bundlers to resolve and bundle the packages properly. Without this it's hard to include the dynamically loaded internal javascript files.

**Fixes** 
@ffmpeg/core and @ffmpeg/core-mt missing export for the ffmpeg-core.worker.js file.
#758