### PR TITLE
Fix: svelte-kit example url

### DIFF
--- a/apps/website/docs/getting-started/examples.md
+++ b/apps/website/docs/getting-started/examples.md
@@ -58,7 +58,7 @@ any of the examples.
         img="/img/sveltekit-vite.png"
         title="SvelteKit + Vite"
         desc="SvelteKit with Vite (multithread version)"
-        url="https://github.com/ffmpegwasm/ffmpeg.wasm/tree/main/apps/sveltekit-vite-app"
+        url="https://github.com/ffmpegwasm/ffmpeg.wasm/tree/main/apps/sveltekit-app"
       />
     </Grid>
   </Grid>


### PR DESCRIPTION
SvelteKit example URL is broken on the webapp, This PR fixes that to the correct one.