### PR TITLE
Fix typo in migration docs

### DIFF
--- a/apps/website/docs/migration.md
+++ b/apps/website/docs/migration.md
@@ -30,7 +30,7 @@ table to transform 0.11.x to 0.12+
             {"0.11.x": "await ffmpeg.run(...args)", "0.12+": "await ffmpeg.exec([...args])", note: ""},
             {"0.11.x": "ffmpeg.FS.writeFile()", "0.12+": "await ffmpeg.writeFile()", note: ""},
             {"0.11.x": "ffmpeg.FS.readFile()", "0.12+": "await ffmpeg.readFile()", note: ""},
-            {"0.11.x": "ffmpeg.exit()", "0.12+": "await ffmpeg.terminate()", note: ""},
+            {"0.11.x": "ffmpeg.exit()", "0.12+": "ffmpeg.terminate()", note: ""},
             {"0.11.x": "ffmpeg.setLogger()", "0.12+": "ffmpeg.on(\"log\", () => {})", note: ""},
             {"0.11.x": "ffmpeg.setProgress()", "0.12+": "ffmpeg.on(\"progress\", () => {})", note: ""},
             {"0.11.x": "import { fetchFile } from '@ffmpeg/ffmpeg'", "0.12+": "import { fetchFile } from '@ffmpeg/util'", note: ""},


### PR DESCRIPTION
According to the [link](https://github.com/ffmpegwasm/ffmpeg.wasm/blob/c7491937fb0f6d0ed9dc4e3531f960bbbc140973/packages/ffmpeg/src/classes.ts#L295), the return value of the `terminate()` is not promise.
so i think we don't need that

https://github.com/ffmpegwasm/ffmpeg.wasm/blob/c7491937fb0f6d0ed9dc4e3531f960bbbc140973/packages/ffmpeg/src/classes.ts#L295
