### PR TITLE
Updated inactive Links on Angular and React-Vite Apps

### DIFF
--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { RouterOutlet } from '@angular/router';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile, toBlobURL } from '@ffmpeg/util';
 
-const baseURL = 'https://unpkg.com/@ffmpeg/core-mt@0.12.10/dist/esm';
+const baseURL = 'https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.9/dist/esm';
 
 @Component({
   selector: 'app-root',

--- a/apps/react-vite-app/src/App.tsx
+++ b/apps/react-vite-app/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
   const messageRef = useRef<HTMLParagraphElement | null>(null);
 
   const load = async () => {
-    const baseURL = "https://unpkg.com/@ffmpeg/core-mt@0.12.10/dist/esm";
+    const baseURL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.9/dist/esm";
     const ffmpeg = ffmpegRef.current;
     ffmpeg.on("log", ({ message }) => {
       if (messageRef.current) messageRef.current.innerHTML = message;


### PR DESCRIPTION
This pull request includes changes to update the base URL for the `@ffmpeg/core-mt` library in two different files, as the library appears to be inactive. The updates are necessary to transition from using the unpkg CDN to the jsdelivr CDN.

The following URLs have been changed:

`https://unpkg.com/@ffmpeg/core-mt@0.12.10/dist/esm` -> `https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.9/dist/esm`

> Please note that the jsdelivr CDN has been used in other examples, which is why I chose to implement this CDN.