### PR TITLE
Added support for trusted types

### DIFF
--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -63,6 +63,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
+    "@types/trusted-types": "^2.0.7",
     "@ffmpeg/types": "^0.12.4"
   }
 }

--- a/packages/ffmpeg/src/classes.ts
+++ b/packages/ffmpeg/src/classes.ts
@@ -185,17 +185,18 @@ export class FFmpeg {
    * @returns `true` if ffmpeg core is loaded for the first time.
    */
   public load = (
-    { classWorkerURL, ...config }: FFMessageLoadConfig = {},
+    { classWorkerURL, trustedTypePolicy, ...config }: FFMessageLoadConfig = { },
     { signal }: FFMessageOptions = {}
   ): Promise<IsFirst> => {
+    const createScriptURL = ((url: string) => (trustedTypePolicy ?? window.trustedTypes?.defaultPolicy)?.createScriptURL?.(url) ?? url)
     if (!this.#worker) {
       this.#worker = classWorkerURL ?
-        new Worker(new URL(classWorkerURL, import.meta.url), {
+        new Worker(createScriptURL(new URL(classWorkerURL, import.meta.url).toString()), {
           type: "module",
         }) :
         // We need to duplicated the code here to enable webpack
         // to bundle worekr.js here.
-        new Worker(new URL("./worker.js", import.meta.url), {
+        new Worker(createScriptURL(new URL("./worker.js", import.meta.url).toString()), {
           type: "module",
         });
       this.#registerHandlers();
@@ -340,7 +341,7 @@ export class FFmpeg {
     ) as Promise<OK>;
   };
 
-  public mount = (fsType: FFFSType, options: FFFSMountOptions, mountPoint: FFFSPath, ): Promise<OK> => {
+  public mount = (fsType: FFFSType, options: FFFSMountOptions, mountPoint: FFFSPath): Promise<OK> => {
     const trans: Transferable[] = [];
     return this.#send(
       {

--- a/packages/ffmpeg/src/types.ts
+++ b/packages/ffmpeg/src/types.ts
@@ -30,6 +30,11 @@ export interface FFMessageLoadConfig {
    * @defaultValue `./worker.js`
    */
   classWorkerURL?: string;
+
+  /**
+   * Trusted type policy to use on workers
+   */
+  trustedTypePolicy?: TrustedTypePolicy
 }
 
 export interface FFMessageExecData {


### PR DESCRIPTION
I couldnt make an install for some reason. But I wanted to give support for [trusted types](https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy/createScriptURL#input)