### PR TITLE
"ENV key=value" should be used instead of legacy "ENV key value" format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ COPY src/bind /src/src/bind
 COPY src/fftools /src/src/fftools
 COPY build/ffmpeg-wasm.sh build.sh
 # libraries to link
-ENV FFMPEG_LIBS \
+ENV FFMPEG_LIBS="\
       -lx264 \
       -lx265 \
       -lvpx \
@@ -191,7 +191,7 @@ ENV FFMPEG_LIBS \
       -lfribidi \
       -lharfbuzz \
       -lass \
-      -lzimg
+      -lzimg"
 RUN mkdir -p /src/dist/umd && bash -x /src/build.sh \
       ${FFMPEG_LIBS} \
       -o dist/umd/ffmpeg-core.js


### PR DESCRIPTION
The correct format for declaring environment variables and build arguments in a Dockerfile is ENV key=value and ARG key=value, where the variable name (key) and value (value) are separated by an equals sign (=). Historically, Dockerfiles have also supported a space separator between the key and the value (for example, ARG key value). This legacy format is deprecated, and you should only use the format with the equals sign.

[https://docs.docker.com/reference/build-checks/legacy-key-value-format/](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)