### PR TITLE
Fix: Correct @ffmpeg/core-mt version in download-assets.js

### DIFF
--- a/scripts/download-assets.js
+++ b/scripts/download-assets.js
@@ -7,7 +7,7 @@ const ROOT = "public/assets";
 const FFMPEG_VERSION = "0.12.15";
 const UTIL_VERSION = "0.12.2";
 const CORE_VERSION = "0.12.10";
-const CORE_MT_VERSION = "0.12.10";
+const CORE_MT_VERSION = "0.12.9";
 
 const FFMPEG_TGZ = `ffmpeg-${FFMPEG_VERSION}.tgz`;
 const UTIL_TGZ = `util-${UTIL_VERSION}.tgz`;


### PR DESCRIPTION
The `CORE_MT_VERSION` constant in `scripts/download-assets.js` was set to `0.12.10`, which is not a published version for `@ffmpeg/core-mt`. This caused the script to fail when trying to download the non-existent asset (`core-mt-0.12.10.tgz`).

This commit updates the version to `0.12.9`, which is the latest available version according to npm (https://www.npmjs.com/package/@ffmpeg/core-mt), allowing the script to execute successfully. 

- Incorrect version: `0.12.10` (https://registry.npmjs.org/@ffmpeg/core-mt/-/core-mt-0.12.10.tgz - Not Found)
- Correct version: `0.12.9` (https://registry.npmjs.org/@ffmpeg/core-mt/-/core-mt-0.12.9.tgz)