### PR TITLE
Fix util umd entry

### DIFF
--- a/packages/util/webpack.config.cjs
+++ b/packages/util/webpack.config.cjs
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   mode: "production",
-  entry: "./dist/cjs/index.js",
+  entry: "./dist/esm/index.js",
   output: {
     library: "FFmpegUtil",
     libraryTarget: "umd",


### PR DESCRIPTION
npm package `@ffmpeg/util@0.12.2`  has error usage by umd, it would be throw error:  Uncaught ReferenceError: exports is not defined