### PR TITLE
Force amd64 platform and limit final ffmpeg build to prevent crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:master-labs
 
 # Base emsdk image with environment variables.
-FROM emscripten/emsdk:3.1.40 AS emsdk-base
+FROM --platform=linux/amd64 emscripten/emsdk:3.1.40 AS emsdk-base
 ARG EXTRA_CFLAGS
 ARG EXTRA_LDFLAGS
 ARG FFMPEG_ST

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ build:
 	FFMPEG_ST="$(FFMPEG_ST)" \
 	FFMPEG_MT="$(FFMPEG_MT)" \
 		docker buildx build \
+			--platform linux/amd64 \
 			--build-arg EXTRA_CFLAGS \
 			--build-arg EXTRA_LDFLAGS \
 			--build-arg FFMPEG_MT \

--- a/build/ffmpeg.sh
+++ b/build/ffmpeg.sh
@@ -30,4 +30,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./configure "${CONF_FLAGS[@]}" $@
-emmake make -j
+emmake make -j2


### PR DESCRIPTION
Attempting to build on mac m4 w/ 24gb of ram fails due to wrong arch (arm vs amd64) and out of control memory consumption that crashes docker on the last ffmpeg build process unless we limit cpu's to 2 which seems to keep docker around 8GB.  This fixes both things.