### PR TITLE
fix: avoid body stream already read on fallback

### DIFF
--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -106,6 +106,7 @@ export const downloadWithProgress = async (
   cb?: ProgressCallback
 ): Promise<ArrayBuffer> => {
   const resp = await fetch(url);
+  const fallback = resp.clone();
   let buf;
 
   try {
@@ -143,7 +144,7 @@ export const downloadWithProgress = async (
   } catch (e) {
     console.log(`failed to send download progress event: `, e);
     // Fetch arrayBuffer directly when it is not possible to get progress.
-    buf = await resp.arrayBuffer();
+    buf = await fallback.arrayBuffer();
     cb &&
       cb({
         url,


### PR DESCRIPTION
Fix “body stream already read” & Playground stall after switching to jsDelivr.

Why it appeared after switching CDNs:
- unpkg often didn’t send Content-Length, so strict byte check never ran.
- jsDelivr sends a compressed response with Content-Length. Our progress counts decoded bytes, which don’t match the compressed length, so the fallback tried to read the same Response twice.
- In dev, React StrictMode double-invocation makes this more likely to surface. In prod, it stalls the Playground around 90–98%.
- Fix: read the fallback from a cloned Response.