### PR TITLE
add search feature to docusaurus

### DIFF
--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -137,6 +137,11 @@ const config = {
       },
     }),
   plugins: [
+    [require.resolve('@easyops-cn/docusaurus-search-local'), {
+      indexDocs: true,
+      indexBlog: true,
+      hashed: true,
+    }],
     [
       "docusaurus-plugin-typedoc",
       {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.2.0",
+    "@easyops-cn/docusaurus-search-local": "^0.34.0",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/ace": "^0.0.48",
     "docusaurus-plugin-typedoc": "^0.17.5",


### PR DESCRIPTION
As an attempt to make the documentation more user-friendly, I added the search feature using [@easyops-cn/docusaurus-search-local](https://github.com/easyops-cn/docusaurus-search-local).

The next step would be upgrading Docusaurus to v3 ([upgrading guide](https://docusaurus.io/docs/migration/v3)), but that involves more time with dependency and MDX updates. Sticking with this solution for now to deliver the feature immediately.

Search default
<img width="1676" height="546" alt="Screenshot 2025-08-19 at 11 57 37 AM" src="https://github.com/user-attachments/assets/69e77289-d4b9-4e22-b979-5eaeaae43c9c" />

Search action
<img width="1640" height="459" alt="Screenshot 2025-08-19 at 12 10 41 PM" src="https://github.com/user-attachments/assets/b385d1b5-c46b-4c82-ae24-3169c31d64f7" />
