### PR TITLE
Fix x265 build when not using latest Git tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ FROM emsdk-base AS x265-builder
 ENV X265_BRANCH=3.4
 ADD https://github.com/ffmpegwasm/x265.git#$X265_BRANCH /src
 COPY build/x265.sh /src/build.sh
+# Workaround for x265 not generating pkg-config unless on the latest Git tag
+RUN git tag | xargs -r git tag -d && git tag "$X265_BRANCH"
 RUN bash -x /src/build.sh
 
 # Build libvpx


### PR DESCRIPTION
x265 does not generate pkg-config files unless it is on the latest Git tag.
This causes the FFmpeg build to fail later on.
https://github.com/ffmpegwasm/x265/blob/Release_3.4/source/CMakeLists.txt#L694-L717